### PR TITLE
Change Faraday version and update the gem version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,8 @@
 
 ## [0.1.0] - 2023-01-10
 
-- Initial release
+Initial release
+
+## [2.0.0] - 2023-08-03
+
+Faraday version change

--- a/lib/loco_sync/version.rb
+++ b/lib/loco_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LocoSync
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/loco_sync.gemspec
+++ b/loco_sync.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   ]
   spec.extra_rdoc_files = ["README.md"]
 
-  spec.add_dependency "faraday", "~>1.4.2"
+  spec.add_dependency "faraday", ">= 2.0"
   spec.add_dependency "zeitwerk", "~> 2.4"
 end


### PR DESCRIPTION
## Issue Description

We would like to use the loco-sync gem in API project and the required version of Faraday was not compatible with another gem. In this PR I am updating the Faraday gem version and the loco-sync gem version.

Link to the parent issue:
https://olio.atlassian.net/jira/software/c/projects/PT/boards/3?modal=detail&selectedIssue=PT-508
