### PR TITLE
Allow separate import and export locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@ Initial release
 ## [2.0.0] - 2023-08-03
 
 Faraday version change
+
+## [2.1.0] - 2023-08-03
+
+Allow separate import and export locales

--- a/lib/generators/templates/loco_sync_config.rb
+++ b/lib/generators/templates/loco_sync_config.rb
@@ -30,7 +30,10 @@ LocoSync::Config.config do |c|
   #   "untag-all": "unused"
   # }
 
-  # Locales to import or export
+  # The source of truth for key names to be exported to Loco
+  # c.export_locales = ["en"]
+
+  # Locales to import
   # c.locales = ["en"]
 
   # Loco api base url

--- a/lib/loco_sync/version.rb
+++ b/lib/loco_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LocoSync
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/lib/tasks/loco_sync_task.rake
+++ b/lib/tasks/loco_sync_task.rake
@@ -17,7 +17,8 @@ namespace :loco_sync do
 
   desc "Exports translation files from the current Rails project to localise.biz"
   task :export do
-    LocoSync::Config.locales.each do |locale|
+    export_locales = LocoSync::Config.export_locales || LocoSync::Config.locales
+    export_locales do |locale|
       puts "Exporting translations for locale: #{locale}"
       LocoSync::Sync::Export.export!(locale: locale)
     end


### PR DESCRIPTION
We only need to maintain and export one locale yaml file.  This update allows for separate lists of import/export locales in a non-breaking way.