### PR TITLE
Add specs for rake task and fix uncovered error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+- 3.2.2
+cache:
+- bundler: true
+stages:
+- name: tests
+jobs:
+- stage: tests
+  name: Running tests (Ruby)
+  script:
+  - bundle exec rspec

--- a/lib/loco_sync/config.rb
+++ b/lib/loco_sync/config.rb
@@ -4,7 +4,7 @@ module LocoSync
   class Config
     class << self
       attr_accessor :import_api_key, :export_api_key
-      attr_writer :import_opts, :export_opts, :locales_path, :locales, :base_url
+      attr_writer :import_opts, :export_opts, :locales_path, :export_locales, :locales, :base_url
 
       def config
         yield self
@@ -38,6 +38,10 @@ module LocoSync
 
       def locales
         @locales || %w(en)
+      end
+
+      def export_locales
+        @export_locales || %w(en)
       end
 
       def base_url

--- a/lib/loco_sync/version.rb
+++ b/lib/loco_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LocoSync
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/lib/tasks/loco_sync_task.rake
+++ b/lib/tasks/loco_sync_task.rake
@@ -2,7 +2,10 @@
 
 require "rake"
 require "loco_sync"
-require "#{Rails.root}/config/initializers/loco_sync"
+
+if defined?(Rails)
+  require "#{Rails.root}/config/initializers/loco_sync"
+end
 
 namespace :loco_sync do
   desc "Imports translation files from localise.biz to the current Rails project"
@@ -18,7 +21,7 @@ namespace :loco_sync do
   desc "Exports translation files from the current Rails project to localise.biz"
   task :export do
     export_locales = LocoSync::Config.export_locales || LocoSync::Config.locales
-    export_locales do |locale|
+    export_locales.each do |locale|
       puts "Exporting translations for locale: #{locale}"
       LocoSync::Sync::Export.export!(locale: locale)
     end

--- a/loco_sync.gemspec
+++ b/loco_sync.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", ">= 2.0"
   spec.add_dependency "zeitwerk", "~> 2.4"
 
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/loco_sync.gemspec
+++ b/loco_sync.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", ">= 2.0"
   spec.add_dependency "zeitwerk", "~> 2.4"
+
+  spec.add_development_dependency "rspec"
 end

--- a/spec/lib/tasks/loco_sync_task_spec.rb
+++ b/spec/lib/tasks/loco_sync_task_spec.rb
@@ -1,0 +1,42 @@
+require 'loco_sync'
+require 'spec_helper'
+
+describe 'loco_sync Rake tasks' do
+  let(:response) { double({ body: "wibble: wobble" }) }
+
+  before :all do
+    Rake.application.rake_require('loco_sync_task', ['lib/tasks'])
+    Rake::Task.define_task(:environment)
+  end
+
+  before do
+    allow(Faraday).to receive(:new).and_return(double("client", get: response, post: response))
+    allow(LocoSync::Config).to receive(:locales_path).and_return "spec/support/mock/locale"
+  end
+
+  after do
+    remove_translation_file
+  end
+
+  describe 'loco_sync:import' do
+    subject { Rake::Task['loco_sync:import'].invoke }
+
+    it 'imports translations from localise.biz' do
+      expect(LocoSync::Sync::Import).to receive(:import!).with(locale: "en")
+      subject
+    end
+  end
+
+  describe 'loco_sync:export' do
+    before do
+      add_translation_file("en")
+    end
+
+    subject { Rake::Task['loco_sync:export'].invoke }
+
+    it 'exports configured export locales' do
+      expect(LocoSync::Sync::Export).to receive(:export!).with(locale: "en")
+      subject
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "faraday"
 require "yaml"
+require "rake"
 require "loco_sync"
 require_relative "support/file_manager"
 


### PR DESCRIPTION
We were missing test coverage for the rake tasks.  There are added in this pr.  Once added they uncovered an issue with the previous version not handling the new `export_locales` correctly.

- Add test coverage for rake task
- Add missing .each to enumerable 
- Add export locale read/writer to config 