### PR TITLE
Reduce minimum Faraday version

### DIFF
--- a/lib/loco_sync/version.rb
+++ b/lib/loco_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LocoSync
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end

--- a/loco_sync.gemspec
+++ b/loco_sync.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   ]
   spec.extra_rdoc_files = ["README.md"]
 
-  spec.add_dependency "faraday", ">= 2.0"
+  spec.add_dependency "faraday", ">= 1.0"
   spec.add_dependency "zeitwerk", "~> 2.4"
 
   spec.add_development_dependency "rake"


### PR DESCRIPTION
The gemspec was updated to require faraday v2.x, which was not necessary and causes issues using the gem in all environments.

This PR sets the minimum to 1.x