### PR TITLE
Add format=rails when exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@ Faraday version change
 ## [2.1.0] - 2023-08-03
 
 Allow separate import and export locales
+
+## [2.2.0] - 2024-03-14
+
+Add `format=rails` flag when exporting yml

--- a/lib/loco_sync/sync/export.rb
+++ b/lib/loco_sync/sync/export.rb
@@ -34,7 +34,7 @@ module LocoSync
         def params
           config.export_opts.merge({
             locale: locale,
-            path: "/config/locales/#{locale}.yml",
+            path: "/config/locales/#{locale}.yml?format=rails",
           })
         end
       end

--- a/lib/loco_sync/version.rb
+++ b/lib/loco_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LocoSync
-  VERSION = "2.1.2"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
Whilst investigating some issues with list formats, it was discovered that we're not using the Rails yml format