### PR TITLE
Make import fault-tolerant; raise loudly on failed export

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ To sync translations (export then import) with your Rails app and Loco, run the 
 bundle exec rake loco_sync:sync
 ```
 
+## Error handling
+
+- **Import is fault-tolerant.** Any failure (HTTP error, invalid YAML, wrong root key) is logged via `warn` and either leaves the existing locale file in place or writes a `{locale}: {}` placeholder so Rails still boots. Deploys never abort on Loco issues; the next successful import heals any placeholder.
+- **Export is strict.** Any non-2xx response raises with the locale, URL, HTTP status, body excerpt, and exception class so manual exports fail loudly.
+
+## Authentication
+
+The import endpoint (`GET /api/export/locale/{locale}.{ext}`) is CDN-served and only accepts the API key via the `key` query parameter (an `Authorization` header returns 401 "invalid project key"). All other endpoints accept (and prefer) the `Authorization` header. The gem handles this per-endpoint.
+
 ## Running tests
 
 Run `rspec` to run the test suite

--- a/lib/loco_sync/sync/base.rb
+++ b/lib/loco_sync/sync/base.rb
@@ -4,18 +4,60 @@ module LocoSync
   module Sync
     class Base
       class << self
+        # Build the Faraday client used for a Loco API request.
+        #
+        # auth_via: :header (default) sends `Authorization: Loco <key>`. This
+        #           is the preferred mode for endpoints that accept it.
+        # auth_via: :query sends the key as the `key` query parameter. CDN
+        #           endpoints (e.g. GET /api/export/locale/{locale}.{ext})
+        #           only accept this form and will respond with 401
+        #           "invalid project key" if an Authorization header is sent.
+        #
+        # The `raise_error` middleware is added so any non-2xx response
+        # raises a typed `Faraday::Error` instead of returning silently and
+        # leaving callers to inspect status codes by hand.
+        def client(auth_via: :header)
+          query_params = auth_via == :query ? params.merge(key: api_key) : params
+          headers = auth_via == :header ? { "Authorization" => "Loco #{api_key}" } : {}
+
+          Faraday.new(
+            url: url,
+            params: query_params,
+            headers: headers
+          ) do |connection|
+            connection.response :raise_error
+            connection.adapter Faraday.default_adapter
+          end
+        end
+
+        # Build a useful error message from a Faraday::Error, scrubbing
+        # any non-UTF-8 bytes in the response body so the message can be
+        # safely logged and interpolated into Ruby strings.
+        def error_message(operation, locale, error)
+          status =
+            if error.respond_to?(:response_status) && error.response_status
+              error.response_status
+            else
+              error.response&.dig(:status) || "no response"
+            end
+          body =
+            if error.respond_to?(:response_body) && error.response_body
+              error.response_body
+            else
+              error.response&.dig(:body)
+            end
+          "Loco Sync #{operation} failed locale=#{locale} url=#{url} " \
+            "status=#{status}: #{safe_excerpt(body)} (#{error.class})"
+        end
+
+        def safe_excerpt(value, limit = 500)
+          value.to_s.byteslice(0, limit).to_s.dup.force_encoding(Encoding::UTF_8).scrub("?")
+        end
+
         private
 
         def config
           LocoSync::Config
-        end
-
-        def client
-          Faraday.new(
-            url: url,
-            params: params,
-            headers: { "Authorization" => "Loco #{api_key}" }
-          )
         end
       end
     end

--- a/lib/loco_sync/sync/export.rb
+++ b/lib/loco_sync/sync/export.rb
@@ -4,21 +4,27 @@ require_relative "base"
 
 module LocoSync
   module Sync
+    # Pushes the locale file from the local Rails project up to Loco.
+    #
+    # Export is intentionally strict: any non-2xx response raises with the
+    # locale, URL, HTTP status, body excerpt, and exception class. Manual
+    # exports should fail loudly so a broken push doesn't silently swallow
+    # the user's intent.
     class Export < Base
       class << self
         attr_reader :locale
 
         def export!(locale:)
-          translations_file = File.read("#{config.locales_path}/#{locale}.yml")
           @locale = locale
+          translations_file = File.read("#{config.locales_path}/#{locale}.yml")
 
           response = client.post do |req|
             req.body = translations_file
           end
 
           response.body
-        rescue Faraday::Error => e
-          raise "Loco Sync failed to export locale #{locale}: #{e.response[:body]}"
+        rescue Faraday::Error => error
+          raise error_message("export", locale, error)
         end
 
         private
@@ -32,10 +38,10 @@ module LocoSync
         end
 
         def params
-          config.export_opts.merge({
+          config.export_opts.merge(
             locale: locale,
-            path: "/config/locales/#{locale}.yml",
-          })
+            path: "/config/locales/#{locale}.yml"
+          )
         end
       end
     end

--- a/lib/loco_sync/sync/import.rb
+++ b/lib/loco_sync/sync/import.rb
@@ -1,23 +1,48 @@
 # frozen_string_literal: true
 
+require "yaml"
 require_relative "base"
 
 module LocoSync
   module Sync
+    # Imports a locale file from Loco into the local Rails project.
+    #
+    # `GET /api/export/locale/{locale}.{ext}` is CDN-served; CDN endpoints
+    # only accept the API key via the `key` query parameter and respond
+    # with 401 "invalid project key" when an Authorization header is
+    # used (see https://localise.biz/help/developers/api-keys).
+    #
+    # The importer is intentionally fault-tolerant: any failure (HTTP
+    # error, invalid YAML, wrong root key) is logged and the destination
+    # file is either left alone (if it already contains a valid
+    # translation document) or replaced with a `{locale}: {}` placeholder
+    # so Rails still boots. Deploys never abort on Loco issues; the next
+    # successful import heals any placeholder.
     class Import < Base
       class << self
         attr_reader :locale
 
         def import!(locale:)
           @locale = locale
+          destination = "#{config.locales_path}/#{locale}.yml"
 
           begin
-            response = client.get
-          rescue Faraday::Error => e
-            raise "Loco Sync failed to import locale #{locale}: #{e.response[:body]}"
+            response = client(auth_via: :query).get
+          rescue Faraday::Error => error
+            handle_import_failure(destination, error_message("import", locale, error))
+            return
           end
 
-          File.binwrite("#{config.locales_path}/#{locale}.yml", response.body)
+          validation_error = validation_error_for(response.body)
+          if validation_error
+            handle_import_failure(destination, validation_error)
+            return
+          end
+
+          atomic_write(destination, response.body)
+        rescue StandardError => error
+          warn "[loco_sync:import] Unexpected error for locale=#{locale}: #{error.class}: #{error.message}. " \
+               "Leaving #{destination} untouched."
         end
 
         private
@@ -32,6 +57,71 @@ module LocoSync
 
         def params
           config.import_opts
+        end
+
+        def handle_import_failure(destination, reason)
+          warn "[loco_sync:import] #{reason}"
+
+          if existing_file_valid?(destination)
+            warn "[loco_sync:import] Keeping existing #{destination}; translations may be stale."
+          else
+            warn "[loco_sync:import] Writing placeholder to #{destination}; boot will succeed but locale will be empty."
+            write_placeholder(destination, reason)
+          end
+        end
+
+        def validation_error_for(body)
+          parsed =
+            begin
+              YAML.safe_load(body, permitted_classes: [], aliases: true)
+            rescue Psych::SyntaxError => error
+              return "Loco import for locale=#{locale} url=#{url} returned invalid YAML " \
+                     "(#{error.message}). Body: #{safe_excerpt(body)}"
+            end
+
+          return nil if parsed.is_a?(Hash) && parsed.size == 1 && root_matches_locale?(parsed.keys.first)
+
+          root = parsed.is_a?(Hash) ? parsed.keys.inspect : parsed.class
+          "Loco import for locale=#{locale} url=#{url} returned unexpected structure " \
+            "(root was #{root}). Body: #{safe_excerpt(body)}"
+        end
+
+        # Accepts the requested locale, its language tag with a region
+        # subtag (e.g. `ko` request → `ko-KR` response), or the underscore
+        # variant. Loco exports the project's canonical locale code, which
+        # is often more specific than the locale you request by.
+        def root_matches_locale?(root_key)
+          return false unless root_key.is_a?(String)
+
+          root = root_key.downcase
+          prefix = locale.to_s.downcase
+          root == prefix || root.start_with?("#{prefix}-") || root.start_with?("#{prefix}_")
+        end
+
+        def existing_file_valid?(path)
+          return false unless File.exist?(path)
+
+          validation_error_for(File.read(path)).nil?
+        end
+
+        def atomic_write(destination, body)
+          tempfile = "#{destination}.partial"
+          File.binwrite(tempfile, body)
+          File.rename(tempfile, destination)
+        ensure
+          File.delete(tempfile) if File.exist?(tempfile)
+        end
+
+        def write_placeholder(destination, reason)
+          timestamp = Time.now.utc.iso8601
+          safe_reason = safe_excerpt(reason).tr("\n", " ")
+          placeholder = <<~YAML
+            # Placeholder written by loco_sync:import on #{timestamp}.
+            # The import failed and no usable locale file existed on disk.
+            # Reason: #{safe_reason}
+            #{locale}: {}
+          YAML
+          atomic_write(destination, placeholder)
         end
       end
     end

--- a/lib/loco_sync/version.rb
+++ b/lib/loco_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LocoSync
-  VERSION = "2.1.2"
+  VERSION = "2.2.0"
 end

--- a/lib/tasks/loco_sync_task.rake
+++ b/lib/tasks/loco_sync_task.rake
@@ -9,24 +9,20 @@ end
 
 namespace :loco_sync do
   desc "Imports translation files from localise.biz to the current Rails project"
-  task :import do
+  task import: :environment do
     LocoSync::Config.locales.each do |locale|
       puts "Importing translations for locale: #{locale}"
       LocoSync::Sync::Import.import!(locale: locale)
     end
-  rescue StandardError => e
-    abort e.inspect
   end
 
   desc "Exports translation files from the current Rails project to localise.biz"
-  task :export do
+  task export: :environment do
     export_locales = LocoSync::Config.export_locales || LocoSync::Config.locales
     export_locales.each do |locale|
       puts "Exporting translations for locale: #{locale}"
       LocoSync::Sync::Export.export!(locale: locale)
     end
-  rescue StandardError => e
-    abort e.inspect
   end
 
   desc "Sync translations with localise.biz"

--- a/spec/lib/loco_sync/sync/export_spec.rb
+++ b/spec/lib/loco_sync/sync/export_spec.rb
@@ -42,7 +42,7 @@ describe LocoSync::Sync::Export do
       it "raises the error with a useful message" do
         expect do
           subject.export!(locale: locale)
-        end.to raise_error("Loco Sync failed to export locale #{locale}: unauthorized error")
+        end.to raise_error(/Loco Sync export failed locale=#{locale} url=.* status=401: unauthorized error/)
       end
     end
   end

--- a/spec/lib/loco_sync/sync/import_spec.rb
+++ b/spec/lib/loco_sync/sync/import_spec.rb
@@ -17,32 +17,77 @@ describe LocoSync::Sync::Import do
   describe ".import!" do
     before do
       allow(Faraday).to receive(:new).and_return connection
+      allow(LocoSync::Config).to receive(:locales_path).and_return locales_path
     end
+
     context "when the request is successful" do
       before do
         allow(connection).to receive(:get).and_return response
         allow(response).to receive(:body).and_return body
-        allow(LocoSync::Config).to receive(:locales_path).and_return locales_path
         subject.import!(locale: locale)
       end
 
-      it "the translations are imported correctly" do
+      it "writes the locale file" do
         expect(translations_files_count).to eq(1)
         expect(YAML.load_file(translations_file)[locale].count).to eq(2)
       end
     end
 
-    context "when the request is unsuccessful" do
+    context "when the response root key matches the locale with a region subtag" do
+      let(:body) { "ko-KR:\n hello: 안녕" }
+      let(:locale) { "ko" }
+
       before do
-        allow(connection).to receive(:get).and_raise(Faraday::UnauthorizedError.new(401,
-                                                                                    { status: 401,
-                                                                                      body: "unauthorized error" }))
+        allow(connection).to receive(:get).and_return response
+        allow(response).to receive(:body).and_return body
+        subject.import!(locale: locale)
       end
 
-      it "raises the error with a useful message" do
-        expect do
+      it "writes the locale file using the Loco response root key" do
+        expect(YAML.load_file(translations_file).keys).to eq(["ko-KR"])
+      end
+    end
+
+    context "when the request is unsuccessful" do
+      before do
+        allow(connection).to receive(:get).and_raise(
+          Faraday::UnauthorizedError.new(401, { status: 401, body: "unauthorized error" })
+        )
+      end
+
+      it "does not raise and writes a placeholder when no usable file exists" do
+        expect { subject.import!(locale: locale) }.not_to raise_error
+        parsed = YAML.load_file(translations_file)
+        expect(parsed.keys).to eq([locale])
+        expect(parsed[locale]).to be_empty
+      end
+
+      context "and a valid locale file already exists" do
+        before do
+          add_translation_file(locale)
+        end
+
+        it "leaves the existing file untouched" do
+          original = File.read(translations_file)
           subject.import!(locale: locale)
-        end.to raise_error("Loco Sync failed to import locale #{locale}: unauthorized error")
+          expect(File.read(translations_file)).to eq(original)
+        end
+      end
+    end
+
+    context "when the response is valid YAML but the wrong shape" do
+      let(:body) { %({"error": "Invalid project key"}) }
+
+      before do
+        allow(connection).to receive(:get).and_return response
+        allow(response).to receive(:body).and_return body
+      end
+
+      it "does not raise and writes a placeholder" do
+        expect { subject.import!(locale: locale) }.not_to raise_error
+        parsed = YAML.load_file(translations_file)
+        expect(parsed.keys).to eq([locale])
+        expect(parsed[locale]).to be_empty
       end
     end
   end


### PR DESCRIPTION
This release bakes in the deploy-resiliency work that previously lived as a local rake task override in the OLIOEX/api repo. Three changes:

  1. Faraday client now uses the `raise_error` middleware so non-2xx responses raise typed `Faraday::Error` subclasses instead of being silently written into locale YAML files. Before this change, a 401 "invalid project key" body would happily land in `config/locales/{en,es,ko}.yml` and kill the next boot with the I18n `deep_merge` "Integer into Hash" error.

  2. Import is fault-tolerant. HTTP errors, invalid YAML, and wrong root keys are logged via `warn` and the destination file is either left in place (if it already contains a valid translation document) or replaced with a `{locale}: {}` placeholder so Rails still boots. The validator accepts the requested locale, its `<locale>-<region>` variant (e.g. `ko` → `ko-KR`), or the underscore variant. Writes go through a `.partial` tempfile and atomic rename so a half-completed download can never leave a corrupt locale file behind. Non-UTF-8 bytes in response bodies are scrubbed before they reach log messages or the placeholder comment, so binary-encoded error bodies can't crash the task.

  3. Export remains strict and raises with locale, URL, HTTP status, body excerpt, and the exception class so manual pushes fail loudly.

The rake tasks now depend on `:environment` and use `raise` instead of `abort e.inspect` so the backtrace and context survive.

The import endpoint is CDN-served by Loco; CDN endpoints only accept the API key via the `key` query parameter and return 401 "invalid project key" when an Authorization header is sent. The base client gains an `auth_via:` option (`:header` default, `:query` for CDN).